### PR TITLE
Uninit val

### DIFF
--- a/lib/LCS/BV.pm
+++ b/lib/LCS/BV.pm
@@ -45,7 +45,7 @@ sub LCS {
 
     my $S = ~0;
 
-    my $Vs = [];
+    my $Vs = [~0];
     my ($y,$u);
 
     # outer loop

--- a/t/10_basic_lcs.t
+++ b/t/10_basic_lcs.t
@@ -81,6 +81,10 @@ my $examples = [
     '_bcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVYZ'],
   [ 'aabbcc',
     'abc'],
+  [ 'aaaabbbbcccc',
+    'abc'],
+  [ 'aaaabbcc',
+    'abc'],
 ];
 
 

--- a/t/10_basic_lcs.t
+++ b/t/10_basic_lcs.t
@@ -79,6 +79,8 @@ my $examples = [
     '_bcdefgh'],
   [ 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVY_',
     '_bcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVYZ'],
+  [ 'aabbcc',
+    'abc'],
 ];
 
 


### PR DESCRIPTION
I’m using Perl 5.30.0 and `LCS::BV`.

I’ve come across a case that needs to be fixed:

```
$ cat blech.pl 
#!/usr/bin/env perl

use LCS::BV;

my @a = split //, 'aabbcc';
my @b = split //, 'abc';
my @l = LCS::BV->LCS(\@a, \@b);
$ perl blech.pl
Use of uninitialized value in 1's complement (~) at /Users/adeishs/perl5/perlbrew/perls/perl-5.30.0/lib/site_perl/5.30.0/LCS/BV.pm line 73.
Argument "" isn't numeric in bitwise and (&) at /Users/adeishs/perl5/perlbrew/perls/perl-5.30.0/lib/site_perl/5.30.0/LCS/BV.pm line 73.
```

The same thing happens when we replace the string that got splitted to `@a` to `'aaaabbbbcccc'` or `'aaabbbccc'` or `'aaaabbcc'`….