### PR TITLE
Speed up LCS

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'perl', '5.010001';
 
-# requires 'Some::Module', 'VERSION';
+requires 'Math::BigInt', '1.999818';
+recommends 'Math::BigInt::GMP', '1.6007';
 
 on test => sub {
   requires 'Test::More', '0.88';

--- a/lib/LCS/BV.pm
+++ b/lib/LCS/BV.pm
@@ -153,12 +153,12 @@ sub LCS {
     else {
       my $m = $j > 0 ? exists $Vs->[$j-1] : 0;
       if ($m) {
-          $m = !($Vs->[$j - 1]->copy()->bnot()->band($mask)->is_zero());
+        $m = !($Vs->[$j - 1]->copy()->bnot()->band($mask)->is_zero());
       }
       unless ($m) {
-         unshift @lcs, [$i,$j];
-         $i--;
-         $mask->brsft(1);
+        unshift @lcs, [$i,$j];
+        $i--;
+        $mask->brsft(1);
       }
       $j--;
     }

--- a/lib/LCS/BV.pm
+++ b/lib/LCS/BV.pm
@@ -147,13 +147,18 @@ sub LCS {
   my $i = $amax;
   my $j = $bmax;
 
+  # really: $mask = 1 << $i
+  # this is faster than creating a new object with value = 1 and then shift
+  $mask->bxor($mask);
+  $mask->binc();
+  $mask->blsft($i);
+
   while ($i >= $amin && $j >= $bmin) {
-    $mask = Math::BigInt->bone();
-    $mask->blsft($i);
     my $Vm = $Vs->[$j]->copy();
     $Vm->band($mask);
-    if ($Vm) {
+    unless ($Vm->is_zero()) {
       $i--;
+      $mask->brsft(1);
     }
     else {
       my $existing = exists $Vs->[$j-1];
@@ -170,6 +175,7 @@ sub LCS {
       ) {
          unshift @lcs, [$i,$j];
          $i--;
+         $mask->brsft(1);
       }
       $j--;
     }

--- a/lib/LCS/BV.pm
+++ b/lib/LCS/BV.pm
@@ -87,7 +87,7 @@ sub _count_bits {
 sub LCS {
   my ($self, $a, $b) = @_;
 
-  use Math::BigInt lib => 'GMP';
+  use Math::BigInt try => 'GMP';
 
   my ($amin, $amax, $bmin, $bmax) = (0, $#$a, 0, $#$b);
 

--- a/lib/LCS/BV.pm
+++ b/lib/LCS/BV.pm
@@ -129,10 +129,10 @@ sub LCS {
   # outer loop
   for my $j ($bmin..$bmax) {
     if (defined $positions->{$b->[$j]}) {
-      $y = $positions->{$b->[$j]}->copy();
+      $y = $positions->{$b->[$j]};
     }
     else {
-      $y = $b0->copy();
+      $y = $b0;
     }
     # [Hyy04]
     $u = $S->copy();

--- a/lib/LCS/BV.pm
+++ b/lib/LCS/BV.pm
@@ -135,8 +135,10 @@ sub LCS {
       $y = $b0;
     }
     # [Hyy04]
+    # $u = $S & $y
     $u = $S->copy();
     $u->band($y);
+    # $S = ($S + $u) | ($S - $u)
     my $S_int = $S->as_int();
     $S = $S_int + $u;
     $S->bior($S_int - $u);
@@ -161,18 +163,14 @@ sub LCS {
       $mask->brsft(1);
     }
     else {
-      my $existing = exists $Vs->[$j-1];
-      my $Vn;
-      if ($existing) {
-        $Vn = $Vs->[$j - 1]->copy();
+      my $m = $j > 0 ? exists $Vs->[$j-1] : 0;
+      if ($m) {
+        my $Vn = $Vs->[$j - 1]->copy();
         $Vn->bnot();
         $Vn->band($mask);
+        $m = !$Vn->is_zero();
       }
-      unless (
-         $j
-         && $existing
-         && $Vn
-      ) {
+      unless ($m) {
          unshift @lcs, [$i,$j];
          $i--;
          $mask->brsft(1);

--- a/lib/LCS/BV.pm
+++ b/lib/LCS/BV.pm
@@ -130,7 +130,8 @@ sub LCS {
     # $u = $S & $y
     $u = $S->copy()->band($y);
     # $S = ($S + $u) | ($S - $u)
-    $S->badd($u)->bior($S->copy->bsub($u));
+    my $Smu = $S->copy->bsub($u);
+    $S->badd($u)->bior($Smu);
     $Vs->[$j] = $S->copy();
   }
 

--- a/lib/LCS/BV.pm
+++ b/lib/LCS/BV.pm
@@ -116,9 +116,7 @@ sub LCS {
 
   # cannot do a simple NOT with bnot here as it will turn the integer into
   # a negative value
-  my $S = Math::BigInt->bone();
-  $S->blsft($amax + 1);
-  $S--;
+  my $S = Math::BigInt->bone()->blsft($amax + 1)->bdec();
 
   my $b0 = Math::BigInt->new(0);
   $b0->accuracy($S->accuracy());
@@ -131,12 +129,10 @@ sub LCS {
     $y = $positions->{$b->[$j]} // $b0;
     # [Hyy04]
     # $u = $S & $y
-    $u = $S->copy();
-    $u->band($y);
+    $u = $S->copy()->band($y);
     # $S = ($S + $u) | ($S - $u)
     my $S_int = $S->as_int();
-    $S = $S_int + $u;
-    $S->bior($S_int - $u);
+    $S->badd($u)->bior($S_int - $u);
     $Vs->[$j] = $S->copy();
   }
 
@@ -146,13 +142,10 @@ sub LCS {
 
   # really: $mask = 1 << $i
   # this is faster than creating a new object with value = 1 and then shift
-  $mask->bxor($mask);
-  $mask->binc();
-  $mask->blsft($i);
+  $mask->bxor($mask)->binc()->blsft($i);
 
   while ($i >= $amin && $j >= $bmin) {
-    my $Vm = $Vs->[$j]->copy();
-    $Vm->band($mask);
+    my $Vm = $Vs->[$j]->copy()->band($mask);
     unless ($Vm->is_zero()) {
       $i--;
       $mask->brsft(1);
@@ -160,10 +153,7 @@ sub LCS {
     else {
       my $m = $j > 0 ? exists $Vs->[$j-1] : 0;
       if ($m) {
-        my $Vn = $Vs->[$j - 1]->copy();
-        $Vn->bnot();
-        $Vn->band($mask);
-        $m = !$Vn->is_zero();
+          $m = !($Vs->[$j - 1]->copy()->bnot()->band($mask)->is_zero());
       }
       unless ($m) {
          unshift @lcs, [$i,$j];

--- a/lib/LCS/BV.pm
+++ b/lib/LCS/BV.pm
@@ -128,12 +128,7 @@ sub LCS {
 
   # outer loop
   for my $j ($bmin..$bmax) {
-    if (defined $positions->{$b->[$j]}) {
-      $y = $positions->{$b->[$j]};
-    }
-    else {
-      $y = $b0;
-    }
+    $y = $positions->{$b->[$j]} // $b0;
     # [Hyy04]
     # $u = $S & $y
     $u = $S->copy();

--- a/lib/LCS/BV.pm
+++ b/lib/LCS/BV.pm
@@ -118,8 +118,7 @@ sub LCS {
   # a negative value
   my $S = Math::BigInt->bone()->blsft($amax + 1)->bdec();
 
-  my $b0 = Math::BigInt->new(0);
-  $b0->accuracy($S->accuracy());
+  my $b0 = Math::BigInt->new(0)->accuracy($S->accuracy());
 
   my $Vs = [];
   my ($y,$u);
@@ -131,8 +130,7 @@ sub LCS {
     # $u = $S & $y
     $u = $S->copy()->band($y);
     # $S = ($S + $u) | ($S - $u)
-    my $S_int = $S->as_int();
-    $S->badd($u)->bior($S_int - $u);
+    $S->badd($u)->bior($S->copy->bsub($u));
     $Vs->[$j] = $S->copy();
   }
 

--- a/lib/LCS/BV.pm
+++ b/lib/LCS/BV.pm
@@ -103,19 +103,20 @@ sub LCS {
   my $positions;
   my @lcs;
 
+  my $mask = Math::BigInt->bone();
+  $mask->blsft($amin);
   for ($amin..$amax) {
     my $p = $a->[$_];
-    my $mask = Math::BigInt->bone();
-    $mask->blsft($_);
     unless (defined $positions->{$p}) {
       $positions->{$p} = Math::BigInt->new(0);
     }
     $positions->{$p}->bior($mask);
+    $mask->blsft(1);
   }
 
   # cannot do a simple NOT with bnot here as it will turn the integer into
   # a negative value
-  my $S = Math::BigInt->new(1);
+  my $S = Math::BigInt->bone();
   $S->blsft($amax + 1);
   $S--;
 
@@ -147,7 +148,7 @@ sub LCS {
   my $j = $bmax;
 
   while ($i >= $amin && $j >= $bmin) {
-    my $mask = Math::BigInt->bone();
+    $mask = Math::BigInt->bone();
     $mask->blsft($i);
     my $Vm = $Vs->[$j]->copy();
     $Vm->band($mask);


### PR DESCRIPTION
I’ve tried using `Math::BigInt` with optional `Math::BigInt::GMP` use (if installed, with fallback to the plain `Math::BigInt`).

It’s now about 2.5 times as fast as using `bigint`.

On my machine, the speeds measured with `xt/50_diff_bench.t` are:

| Library | Approx. rate/second|
| :--- | ---: |
| `bigint` | 700 |
| `Math::BigInt` | 1,100 |
| `Math::BigInt::GMP` | 1,700 |

The bad news is that the code is now a bit longer.